### PR TITLE
drafts startDrag logic

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { Result } from './interfaces/Result';
 let searchResultInit: Result[] = [];
 let nomListInit: Result[] = [];
 let nommedCacheInit: Set<string> = new Set();
+let dragCoordsInit: [number, number] = [NaN, NaN];
 
 const buildErrorResult = (error: string): Result[] => {
     return [{ "Title": error, "Year": '', "imdbID": '', "Type": '', "Poster": '' }];
@@ -36,7 +37,7 @@ function App() {
     const [nomList, setNomList] = useState(nomListInit);
 
     const [dragItem, setDragItem] = useState(NaN);
-    const [dragCoords, setDragCoords] = useState([NaN, NaN]);
+    const [dragCoords, setDragCoords] = useState(dragCoordsInit);
 
     const addNom = (nom: Result) => {
         if (nommed.has(nom.imdbID)) return;
@@ -67,26 +68,13 @@ function App() {
         setDragItem(id);
 
         const onMouseMove = (event: MouseEvent) => {
-            setDragCoords([event.clientX, event.clientY]);
-            // how do I grab dragelement in order to hide within react? 
-            // dragelement.hidden = true;
-            let elemBelow = document.elementFromPoint(event.clientX, event.clientY);
-            // dragelement.hidden = false;
-
-            let droppable = elemBelow?.closest('#dragItem');
-            // how do I get id from within droppable in order to perform swap? 
-            /* Swap Logic: 
-                given origin id & placement id that don't equal
-                injection swap origin towards placement id until it has swapped with placement, then setState new ordering into nomList
-            */
+            console.log(event.clientX, event.clientY);
         }
 
         document.addEventListener('mousemove', onMouseMove);
 
         const onMouseUp = () => {
             setDragItem(NaN);
-            setDragCoords([NaN, NaN]);
-
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
             
@@ -136,6 +124,9 @@ return (
                 removeNom={removeNom}
                 nommed={nommed}
                 startDrag={startDrag}
+
+                dragId={dragItem}
+                dragCoords={dragCoords}
                 />)
         } />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,9 @@ function App() {
     const [nommed, setNommed] = useState(nommedCacheInit);
     const [nomList, setNomList] = useState(nomListInit);
 
+    const [dragItem, setDragItem] = useState(NaN);
+    const [dragCoords, setDragCoords] = useState([NaN, NaN]);
+
     const addNom = (nom: Result) => {
         if (nommed.has(nom.imdbID)) return;
         setNommed(produce(nommed, draft => {
@@ -58,6 +61,38 @@ function App() {
         setNomList(produce(nomList, draft => {
             return draft.filter((nom) => nom.imdbID !== id);
         }));
+    }
+
+    const startDrag = (id: number) => {
+        setDragItem(id);
+
+        const onMouseMove = (event: MouseEvent) => {
+            setDragCoords([event.clientX, event.clientY]);
+            // how do I grab dragelement in order to hide within react? 
+            // dragelement.hidden = true;
+            let elemBelow = document.elementFromPoint(event.clientX, event.clientY);
+            // dragelement.hidden = false;
+
+            let droppable = elemBelow?.closest('#dragItem');
+            // how do I get id from within droppable in order to perform swap? 
+            /* Swap Logic: 
+                given origin id & placement id that don't equal
+                injection swap origin towards placement id until it has swapped with placement, then setState new ordering into nomList
+            */
+        }
+
+        document.addEventListener('mousemove', onMouseMove);
+
+        const onMouseUp = () => {
+            setDragItem(NaN);
+            setDragCoords([NaN, NaN]);
+
+            document.removeEventListener('mousemove', onMouseMove);
+            document.removeEventListener('mouseup', onMouseUp);
+            
+        }
+
+        document.addEventListener('mouseup', onMouseUp);
     }
 
 return (
@@ -85,6 +120,10 @@ return (
                 addNom={addNom}
                 removeNom={removeNom}
                 nommed={nommed}
+                startDrag={startDrag}
+
+                dragId={dragItem}
+                dragCoords={dragCoords}
                 />)
         } />
 
@@ -96,6 +135,7 @@ return (
                 addNom={addNom}
                 removeNom={removeNom}
                 nommed={nommed}
+                startDrag={startDrag}
                 />)
         } />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,7 +115,6 @@ return (
                 startDrag={startDrag}
 
                 dragId={dragItem}
-                dragCoords={dragCoords}
                 />)
         } />
 
@@ -130,7 +129,6 @@ return (
                 startDrag={startDrag}
 
                 dragId={dragItem}
-                dragCoords={dragCoords}
                 />)
         } />
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { Route, Redirect, useHistory } from 'react-router-dom';
 import SearchController from './components/Search/SearchController';
 import ResultView from './components/Result/ResultView';
 
+import MovieCardMini from './components/Result/MovieCardMini';
+import CrossSVG from './svg/CrossSVG';
+
 import { Result } from './interfaces/Result';
 /*
     "Title": string;
@@ -68,13 +71,14 @@ function App() {
         setDragItem(id);
 
         const onMouseMove = (event: MouseEvent) => {
-            console.log(event.clientX, event.clientY);
+            setDragCoords([event.clientX, event.clientY]);
         }
 
         document.addEventListener('mousemove', onMouseMove);
 
         const onMouseUp = () => {
             setDragItem(NaN);
+            setDragCoords([NaN, NaN]);
             document.removeEventListener('mousemove', onMouseMove);
             document.removeEventListener('mouseup', onMouseUp);
             
@@ -129,6 +133,30 @@ return (
                 dragCoords={dragCoords}
                 />)
         } />
+
+        {
+
+        !isNaN(dragItem) && !isNaN(dragCoords[0])
+        ?
+        <div
+        style={{
+            position: 'absolute', zIndex: 2, 
+            left: `${!isNaN(dragCoords[0]) ? dragCoords[0] : '0'}px`,
+            top: `${!isNaN(dragCoords[1]) ? dragCoords[1] : '0'}px`
+        }}
+        id='draggedItem'>
+            <MovieCardMini 
+            key={dragItem} 
+            movieData={nomList[dragItem]} 
+            addOrRemove={() => removeNom(nomList[dragItem].imdbID)}
+            startDrag={() => startDrag(dragItem)}>
+                <CrossSVG />
+            </MovieCardMini>
+        </div>
+        :
+        null
+
+        }
 
         <div className='nav_cont'>
             <div className='nav_item'

--- a/src/components/Result/MovieCardMini.tsx
+++ b/src/components/Result/MovieCardMini.tsx
@@ -22,7 +22,8 @@ function MovieCardMini(props: Props) {
 return (
 <>
 <div className={miniCardStyle.card_cont}
-onMouseDown={startDrag()}
+draggable={false}
+onMouseDown={() => startDrag()}
 >
 
     <img className={miniCardStyle.movie_img}

--- a/src/components/Result/MovieCardMini.tsx
+++ b/src/components/Result/MovieCardMini.tsx
@@ -10,17 +10,20 @@ import { Result } from '../../interfaces/Result';
 interface Props {
     movieData: Result,
     children: JSX.Element,
-    addOrRemove: Function
+    addOrRemove: Function,
+    startDrag: Function
 }
 
 function MovieCardMini(props: Props) {
-    const { movieData, addOrRemove } = props;
+    const { movieData, addOrRemove, startDrag } = props;
 
     const [nomText, setNomText] = useState('Nom!');
 
 return (
 <>
-<div className={miniCardStyle.card_cont}>
+<div className={miniCardStyle.card_cont}
+onMouseDown={startDrag()}
+>
 
     <img className={miniCardStyle.movie_img}
     src={movieData.Poster} 

--- a/src/components/Result/MovieCardNoms.tsx
+++ b/src/components/Result/MovieCardNoms.tsx
@@ -26,7 +26,11 @@ if dragged {
 
 return (
 <>
-<div>
+<div
+style={{
+    visibility: dragId === id ? 'hidden' : 'visible'
+}}
+>
 <MovieCardMini 
 key={id} 
 movieData={movie} 

--- a/src/components/Result/MovieCardNoms.tsx
+++ b/src/components/Result/MovieCardNoms.tsx
@@ -11,14 +11,13 @@ interface Props {
     id: number,
     removeNom: Function,
     startDrag: Function,
-    dragCoords: [number, number],
     dragId: number
 }
 
 function MovieCardNoms(props: Props) {
 
     const {movie, id, removeNom} = props;
-    const {dragCoords, startDrag, dragId} = props;
+    const {startDrag, dragId} = props;
 /*
 if dragged {
     render twice, but also in a positioned div wrapper
@@ -27,6 +26,7 @@ if dragged {
 
 return (
 <>
+<div>
 <MovieCardMini 
 key={id} 
 movieData={movie} 
@@ -34,24 +34,8 @@ addOrRemove={() => removeNom(movie.imdbID)}
 startDrag={() => startDrag(id)}>
     <CrossSVG />
 </MovieCardMini>
-
-{
-dragId === id
-?
-<div
-style={{position: 'absolute', zIndex: 2}}
-id='draggedItem'>
-    <MovieCardMini 
-    key={id} 
-    movieData={movie} 
-    addOrRemove={() => removeNom(movie.imdbID)}
-    startDrag={startDrag(id)}>
-        <CrossSVG />
-    </MovieCardMini>
 </div>
-:
-null
-}
+
 </>
 
 )

--- a/src/components/Result/MovieCardNoms.tsx
+++ b/src/components/Result/MovieCardNoms.tsx
@@ -11,13 +11,14 @@ interface Props {
     id: number,
     removeNom: Function,
     startDrag: Function,
-    dragCoords: [number, number]
+    dragCoords: [number, number],
+    dragId: number
 }
 
 function MovieCardNoms(props: Props) {
 
     const {movie, id, removeNom} = props;
-    const {dragCoords, startDrag} = props;
+    const {dragCoords, startDrag, dragId} = props;
 /*
 if dragged {
     render twice, but also in a positioned div wrapper
@@ -35,19 +36,16 @@ startDrag={() => startDrag(id)}>
 </MovieCardMini>
 
 {
-!isNaN(dragCoords[0])
+dragId === id
 ?
 <div
-style={{
-    position: 'absolute',
-    left: `${dragCoords[0]}px`,
-    top: `${dragCoords[1]}px`
-}}>
+style={{position: 'absolute', zIndex: 2}}
+id='draggedItem'>
     <MovieCardMini 
     key={id} 
     movieData={movie} 
     addOrRemove={() => removeNom(movie.imdbID)}
-    startDrag={() => startDrag(id)}>
+    startDrag={startDrag(id)}>
         <CrossSVG />
     </MovieCardMini>
 </div>

--- a/src/components/Result/MovieCardNoms.tsx
+++ b/src/components/Result/MovieCardNoms.tsx
@@ -1,0 +1,62 @@
+
+import React from 'react';
+
+import MovieCardMini from './MovieCardMini';
+import CrossSVG from '../../svg/CrossSVG';
+
+import { Result } from '../../interfaces/Result';
+
+interface Props {
+    movie: Result,
+    id: number,
+    removeNom: Function,
+    startDrag: Function,
+    dragCoords: [number, number]
+}
+
+function MovieCardNoms(props: Props) {
+
+    const {movie, id, removeNom} = props;
+    const {dragCoords, startDrag} = props;
+/*
+if dragged {
+    render twice, but also in a positioned div wrapper
+}
+*/
+
+return (
+<>
+<MovieCardMini 
+key={id} 
+movieData={movie} 
+addOrRemove={() => removeNom(movie.imdbID)}
+startDrag={() => startDrag(id)}>
+    <CrossSVG />
+</MovieCardMini>
+
+{
+!isNaN(dragCoords[0])
+?
+<div
+style={{
+    position: 'absolute',
+    left: `${dragCoords[0]}px`,
+    top: `${dragCoords[1]}px`
+}}>
+    <MovieCardMini 
+    key={id} 
+    movieData={movie} 
+    addOrRemove={() => removeNom(movie.imdbID)}
+    startDrag={() => startDrag(id)}>
+        <CrossSVG />
+    </MovieCardMini>
+</div>
+:
+null
+}
+</>
+
+)
+}
+
+export default MovieCardNoms;

--- a/src/components/Result/MovieCardResult.tsx
+++ b/src/components/Result/MovieCardResult.tsx
@@ -1,0 +1,32 @@
+
+import React from 'react';
+
+import MovieCardMini from './MovieCardMini';
+import CheckSVG from '../../svg/CheckSVG';
+
+import { Result } from '../../interfaces/Result';
+
+interface Props {
+    movie: Result,
+    nommed: Set<string>,
+    id: number,
+    addNom: Function
+}
+
+function MovieCardResult(props: Props) {
+    const {movie, nommed, id, addNom} = props
+
+return (
+<>
+<MovieCardMini 
+key={id} 
+movieData={movie} 
+addOrRemove={() => addNom(movie)}
+startDrag={() => null}>
+    <CheckSVG hasNom={nommed.has(movie.imdbID)} />
+</MovieCardMini>
+</>
+)
+}
+
+export default MovieCardResult;

--- a/src/components/Result/ResultStyles/MovieCardMini.module.css
+++ b/src/components/Result/ResultStyles/MovieCardMini.module.css
@@ -6,6 +6,9 @@
     align-items: center;
 
     margin: 2px;
+    user-select: none;
+    cursor: pointer;
+
 }
 
 .movie_img {
@@ -28,6 +31,7 @@
     cursor: pointer;
 
     height: 100%;
+    width: 400px;
 }
 
 .nomText {

--- a/src/components/Result/ResultView.tsx
+++ b/src/components/Result/ResultView.tsx
@@ -2,12 +2,8 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 
-import MovieCardMini from './MovieCardMini';
 import MovieCardResult from './MovieCardResult';
 import MovieCardNoms from './MovieCardNoms';
-
-import CheckSVG from '../../svg/CheckSVG';
-import CrossSVG from '../../svg/CrossSVG';
 
 import resultStyles from './ResultStyles/ResultView.module.css';
 
@@ -20,15 +16,14 @@ interface Props {
     removeNom: Function,
     nommed: Set<string>,
     startDrag: Function,
-    dragId: number,
-    dragCoords: [number, number]
+    dragId: number
 }
 
 function ResultView(props: Props) {
     // general noms
     const { movies, error, addNom, removeNom, nommed } = props;
     // drag api
-    const {startDrag, dragId, dragCoords} = props;
+    const {startDrag, dragId} = props;
 
 return (
 <>

--- a/src/components/Result/ResultView.tsx
+++ b/src/components/Result/ResultView.tsx
@@ -39,6 +39,7 @@ render={() => {
 if(!error) {
     return movies.map((m, id) => (
         <MovieCardResult
+        key={id}
         id={id}
         movie={m}
         nommed={nommed}
@@ -53,11 +54,13 @@ if(!error) {
 render={() => movies.map((m, id) => (
 
 <MovieCardNoms 
+key={id}
 id={id}
 movie={m}
 removeNom={removeNom}
 startDrag={startDrag}
 dragCoords={dragCoords}
+dragId={dragId}
 />
 
 ))}/>

--- a/src/components/Result/ResultView.tsx
+++ b/src/components/Result/ResultView.tsx
@@ -59,7 +59,6 @@ id={id}
 movie={m}
 removeNom={removeNom}
 startDrag={startDrag}
-dragCoords={dragCoords}
 dragId={dragId}
 />
 

--- a/src/components/Result/ResultView.tsx
+++ b/src/components/Result/ResultView.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Route } from 'react-router-dom';
 
 import MovieCardMini from './MovieCardMini';
+import MovieCardResult from './MovieCardResult';
+import MovieCardNoms from './MovieCardNoms';
 
 import CheckSVG from '../../svg/CheckSVG';
 import CrossSVG from '../../svg/CrossSVG';
@@ -16,11 +18,17 @@ interface Props {
     error: boolean,
     addNom: Function,
     removeNom: Function,
-    nommed: Set<string>
+    nommed: Set<string>,
+    startDrag: Function,
+    dragId: number,
+    dragCoords: [number, number]
 }
 
 function ResultView(props: Props) {
+    // general noms
     const { movies, error, addNom, removeNom, nommed } = props;
+    // drag api
+    const {startDrag, dragId, dragCoords} = props;
 
 return (
 <>
@@ -30,12 +38,13 @@ render={() => {
 
 if(!error) {
     return movies.map((m, id) => (
-        <MovieCardMini 
-        key={id} 
-        movieData={m} 
-        addOrRemove={() => addNom(m)}>
-            <CheckSVG hasNom={nommed.has(m.imdbID)} />
-        </MovieCardMini>));
+        <MovieCardResult
+        id={id}
+        movie={m}
+        nommed={nommed}
+        addNom={addNom}
+        />
+    ));
 } else return movies[0].Title;
 
 }}/>
@@ -43,12 +52,13 @@ if(!error) {
 <Route path='/noms'
 render={() => movies.map((m, id) => (
 
-<MovieCardMini 
-key={id} 
-movieData={m} 
-addOrRemove={() => removeNom(m.imdbID)}>
-    <CrossSVG />
-</MovieCardMini>
+<MovieCardNoms 
+id={id}
+movie={m}
+removeNom={removeNom}
+startDrag={startDrag}
+dragCoords={dragCoords}
+/>
 
 ))}/>
 


### PR DESCRIPTION
Feature: mouseDown into mouseMove event on a nommed item renders a copy of it absolutely positioned on mouse

[x] - additional listeners applied to document tracking and handling mouse movement
[x] - mouseUp cleans up state and listeners
[x] - hides dragged item

Note: Through this process I notice that performing this effect in react it's safest to build the extra dragged component where the coordinates state resides so it doesn't go through a process of props drilling. 