### PR TITLE
fixes event propagation and draggedItem covering onClick fire

### DIFF
--- a/src/components/Result/MovieCardMini.tsx
+++ b/src/components/Result/MovieCardMini.tsx
@@ -18,7 +18,6 @@ function MovieCardMini(props: Props) {
     const { movieData, addOrRemove, startDrag } = props;
 
     const [nomText, setNomText] = useState('Nom!');
-    const [lockDrag, setLockDrag] = useState(false);
 
     const cardContRef = useRef<HTMLDivElement | null>(null);
     const removerRef = useRef<HTMLDivElement | null>(null);
@@ -37,9 +36,9 @@ function MovieCardMini(props: Props) {
             boundY = node.getBoundingClientRect().top;
         }
 
-        if (!lockDrag) {
-            startDrag([clickX - boundX, clickY - boundY]);
-        }
+
+        startDrag([clickX - boundX, clickY - boundY]);
+
         
     }
 

--- a/src/components/Result/MovieCardMini.tsx
+++ b/src/components/Result/MovieCardMini.tsx
@@ -18,8 +18,10 @@ function MovieCardMini(props: Props) {
     const { movieData, addOrRemove, startDrag } = props;
 
     const [nomText, setNomText] = useState('Nom!');
+    const [lockDrag, setLockDrag] = useState(false);
 
     const cardContRef = useRef<HTMLDivElement | null>(null);
+    const removerRef = useRef<HTMLDivElement | null>(null);
 
     const handleDrag = (ev: React.MouseEvent) => {
         const clickX = ev.clientX;
@@ -35,7 +37,10 @@ function MovieCardMini(props: Props) {
             boundY = node.getBoundingClientRect().top;
         }
 
-        startDrag([clickX - boundX, clickY - boundY]);
+        if (!lockDrag) {
+            startDrag([clickX - boundX, clickY - boundY]);
+        }
+        
     }
 
 return (
@@ -54,8 +59,11 @@ onMouseDown={(ev) => handleDrag(ev)}
     <p className={miniCardStyle.movie_title}>
     {movieData.Title} ({movieData.Year})
     </p>
-    <div className={miniCardStyle.checkbox_cont}
-    onMouseDown={() => setNomText('owo;')}
+    <div className={miniCardStyle.checkbox_cont} ref={removerRef}
+    onMouseDown={(ev) => {
+        setNomText('owo;');
+        ev.stopPropagation();
+    }}
     onMouseUp={() => setNomText('Nom!')}
     onMouseLeave={() => setNomText('Nom!')}
 

--- a/src/components/Result/ResultStyles/MovieCardMini.module.css
+++ b/src/components/Result/ResultStyles/MovieCardMini.module.css
@@ -18,10 +18,16 @@
 
 .movie_title {
     font-size: .9rem;
+    width: 340px;
+}
+
+@media (min-width: 650px) {
+    .movie_title {
+        width: 400px;
+    }
 }
 
 .checkbox_cont {
-    flex-grow: 1;
 
     display: flex;
     justify-content: flex-end;
@@ -31,7 +37,7 @@
     cursor: pointer;
 
     height: 100%;
-    width: 400px;
+
 }
 
 .nomText {


### PR DESCRIPTION
Fix: stops mouseDown propagation from remove movie btn

[x] - prevent propagation on mouseDown
[x] - uniform css containing the same size movie card when held vs. in list

Reason: mouseDown was propagating out from remove button to generate an absolutely positioned over mouse that would cover onClick from fully firing on remove button