### PR TITLE
cleans up drag-drop state changes, seems to fix the inconsistent issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,6 @@ function App() {
 
     const startDrag = (id: number) => (shift: [number, number]) => {
         setDragItem(id);
-
         const onMouseMove = (event: MouseEvent) => {
             setDragCoords([event.clientX - shift[0], event.clientY - shift[1]]);
 
@@ -88,13 +87,16 @@ function App() {
             if (elemBelow?.id.split('_')[0] !== 'nom') return;
 
             const swapId = +elemBelow?.id.split('_')[1];
+
             if (swapId === dragItem) return;
             setDragItem((capturedDragId) => {
+                if (isNaN(capturedDragId)) return capturedDragId;
+
                 setNomList(performDrag(capturedDragId, swapId, nomList));
                 return swapId;
+ 
             });
-            
-            
+ 
         }
 
         document.addEventListener('mousemove', onMouseMove);

--- a/src/components/Result/MovieCardMini.tsx
+++ b/src/components/Result/MovieCardMini.tsx
@@ -36,10 +36,8 @@ function MovieCardMini(props: Props) {
             boundY = node.getBoundingClientRect().top;
         }
 
-
         startDrag([clickX - boundX, clickY - boundY]);
 
-        
     }
 
 return (

--- a/src/components/Result/ResultStyles/MovieCardMini.module.css
+++ b/src/components/Result/ResultStyles/MovieCardMini.module.css
@@ -8,7 +8,6 @@
     margin: 2px;
     user-select: none;
     cursor: pointer;
-
 }
 
 .movie_img {

--- a/src/helpers/performDrag.ts
+++ b/src/helpers/performDrag.ts
@@ -11,14 +11,16 @@ injection swap array from startId until swapped with endId
 
         let i = startId;
 
-        while (i !== endId) {
-            console.log(startId, endId);
-            let mod_i = startId > endId ? i-1 : i+1;
-            console.log(mod_i);
-            [draft[i], draft[mod_i]] = [draft[mod_i], draft[i]]
-
-            if (startId > endId) i--;
-            if (endId > startId) i++;
+        if (startId > endId) {
+            while (i > endId) {
+                [draft[i], draft[i-1]] = [draft[i-1], draft[i]];
+                i--;
+            }
+        } else {
+            while (i < endId) {
+                [draft[i], draft[i+1]] = [draft[i+1], draft[i]];
+                i++;
+            }
         }
 
         return draft;


### PR DESCRIPTION
Fix: cleans up state changes and algorithm handling drag/drop

[x] - retrieves up to date dragId with setState and checks for NaN instead of using closed state variable
[x] - rewrites easier to read drag algorithm

This seems to fix a persistent issue where fast drag and drop movements would cause state inconsistencies that showed up as items dragged to the wrong place. 