### PR TITLE
fixes stale nomList ref

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -91,18 +91,20 @@ function App() {
             if (elemBelow?.id.split('_')[0] !== 'nom') return;
 
             const swapId = +elemBelow?.id.split('_')[1];
+
+            // state closed nomLists are out of date for some reason
             setNomList((nomList) => {
 
-                return produce(nomList, draft => {
-                    setDragItem((capturedDragId) => {
-                        if (isNaN(capturedDragId)) return capturedDragId;
-                        if (swapId === capturedDragId) return capturedDragId;
-                        console.log('performDrag resp: ', performDrag(capturedDragId, swapId, nomList));
-                        setNomList(performDrag(capturedDragId, swapId, nomList));
-                        return swapId;
-         
-                    });
-                })
+                setDragItem((capturedDragId) => {
+                    if (isNaN(capturedDragId)) return capturedDragId;
+                    if (swapId === capturedDragId) return capturedDragId;
+
+                    // occurs after this closure is returned
+                    setNomList(performDrag(capturedDragId, swapId, nomList));
+                    return swapId;
+                });
+
+                return nomList;
 
             })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -46,6 +46,10 @@ function App() {
 
     const dragItemRef = useRef<HTMLDivElement | null>(null);
 
+    // React.useEffect(() => {
+    //     console.log('new drag item: ', dragItem);
+    // }, [dragItem]);
+
     const addNom = (nom: Result) => {
         if (nommed.has(nom.imdbID)) return;
         setNommed(produce(nommed, draft => {
@@ -87,15 +91,21 @@ function App() {
             if (elemBelow?.id.split('_')[0] !== 'nom') return;
 
             const swapId = +elemBelow?.id.split('_')[1];
+            setNomList((nomList) => {
 
-            if (swapId === dragItem) return;
-            setDragItem((capturedDragId) => {
-                if (isNaN(capturedDragId)) return capturedDragId;
+                return produce(nomList, draft => {
+                    setDragItem((capturedDragId) => {
+                        if (isNaN(capturedDragId)) return capturedDragId;
+                        if (swapId === capturedDragId) return capturedDragId;
+                        console.log('performDrag resp: ', performDrag(capturedDragId, swapId, nomList));
+                        setNomList(performDrag(capturedDragId, swapId, nomList));
+                        return swapId;
+         
+                    });
+                })
 
-                setNomList(performDrag(capturedDragId, swapId, nomList));
-                return swapId;
- 
-            });
+            })
+
  
         }
 

--- a/src/helpers/performDrag.ts
+++ b/src/helpers/performDrag.ts
@@ -6,7 +6,7 @@ export const performDrag = (startId: number, endId: number, nomList: Result[]): 
 /*
 injection swap array from startId until swapped with endId
 */
-
+    console.log(`startId: ${startId}, endId: ${endId}`);
     return produce(nomList, draft => {
 
         let i = startId;
@@ -16,7 +16,7 @@ injection swap array from startId until swapped with endId
                 [draft[i], draft[i-1]] = [draft[i-1], draft[i]];
                 i--;
             }
-        } else {
+        } else if (startId < endId) {
             while (i < endId) {
                 [draft[i], draft[i+1]] = [draft[i+1], draft[i]];
                 i++;


### PR DESCRIPTION
Fix: grabs up to date nomList during drag & drop to perform further updates on

[x] - uses setState to grab an up to date nomList

Notes: mouseMove event doesn't seem to reclose state vars, so that any incremental updates occurring in the runtime of a single drag & drop mouseDown -> mouseUp cycle requires setState to grab fresh state vars. 